### PR TITLE
ci: Update KiBot action to v2_k9 for KiCad v9

### DIFF
--- a/.github/workflows/kibot_checks.yml
+++ b/.github/workflows/kibot_checks.yml
@@ -27,7 +27,7 @@ jobs:
         submodules: "recursive"
 
     - name: Run KiBot
-      uses: INTI-CMNB/KiBot@v2_k8_1_6_5
+      uses: INTI-CMNB/KiBot@v2_k9_1_8_4
       with:
         config: kicad/checks.kibot.yaml
         # optional - prefix to output defined in config

--- a/.github/workflows/kibot_diff.yml
+++ b/.github/workflows/kibot_diff.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Run KiBot
-        uses: INTI-CMNB/KiBot@v2_k8_1_6_5
+        uses: INTI-CMNB/KiBot@v2_k9_1_8_4
         with:
           config: kicad/diff.kibot.yaml
           # optional - prefix to output defined in config


### PR DESCRIPTION
## Summary
- Update KiBot GitHub Action from `v2_k8_1_6_5` to `v2_k9_1_8_4` in `kibot_diff.yml` and `kibot_checks.yml`
- Prepares CI for KiCad v9 compatibility

## Test plan
- [x] Tested locally with `ghcr.io/inti-cmnb/kicad9_auto:1.8.4` Docker image — diff PDFs generated successfully